### PR TITLE
Create support for enumerated flags.

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ The thinnest possible, yet usable, flags/options parser for Kotlin
 
 > code-golf as a service, by Christian Gruber
 
-***Currently running at:** under 80 lines of code (excluding license and comment lines)*
+***Currently running at:** under 90 lines of code (excluding license and comment lines)*
 
 This library/snippet seeks to be the smallest possible args/flags/options parsing library 
 for Kotlin, dependency free, and suitable for inclusion in kotlin apps or kotlin `.kts`
@@ -16,26 +16,28 @@ debug as other libraries.
 Some basic features:
    - parsing `--foo value` style options
    - parsing `--myflag` style single flags
+   - mapping multiple values (e.g. enums) to flags
    - transformation lambdas for altering flag values and types
    - configuring default values for flags. 
+   - optional (nullable) flags
    - configuring opts/flags to be configured from an env var by default
    - super-basic help text support (and `Opt` objects exposed to allow more robust help text)
    - Multiple options classes using a shared parser (with caveats - they must all
      be instantiated prior to using `help()` or `validate()`)
+   - `parser.validate()` to force early evaluation of the args (defaults to lazy evaluation)
+     - Also reports unknown/undeclared flags
 
 Some (current) limitations (compared to other flag parsers) include:
-   - No up-front init validation (lazily evaluating the flags)
    - No support for commands
-   - flag/option list arguments
-   - No negative flags
+   - positional parameters
+   - No negative flags (i.e. --no-foo to invert the value of foo)
    - No lists of paramters to options (`"-files a b c -someFlag"`)
    - No accumulative flags or options (`"-v -v -v"` turns into verbosity=3, for instance)
-   - No identifying unknown flags (implementable by calling code as `opts` is exposed.)
 
 Other caveats
    - Evaluation is semi-lazy, so using the same parser in different options code has some
      subtleties. (Can instantiate all options classes and then call validate())
-   
+
 These may never be added or "fixed", as it may not be feasible to impelement them and keep
 under or near the ideal goal of 50 lines of code. Contributions (within these constraints)
 welcome. Especially contributions which shorten the code without sacrificing functionality.
@@ -86,16 +88,19 @@ Just go to the source page, and cut and paste it in.
 
 ### Scripting
 
-Get the raw url of the source file, and use in kscript (or another similar system) and use
-`@file:Include("https://raw.githubusercontent.com/geekinasuit/micro-kotlin-args/6bbead09df583a61cf98785967093c97b38f40f2/src/main/kotlin/ArgsParser.kt")`
-in your kotlin script.
-
+Get the raw url of the source file, and use in kscript (or another similar system) and put this
+in your kotlin script:
+```kotlin
+@file:Import("https://raw.githubusercontent.com/geekinasuit/micro-kotlin-args/6bbead09df583a61cf98785967093c97b38f40f2/src/main/kotlin/ArgsParser.kt")
+```
 Ideally you should not use the main branch at head, but lock in a particular commit.
 
 ## Maven Artifact
 
-TBD
-
+Using kscript or some other scripting engine that supports DependsOn annotations:
+```kotlin
+@file:DependsOn("com.geekinasuit.micro:micro-kotlin-args:<version>")
+```
 ## License
 
 Copyright (c) 2021, Christian Gruber, All Rights Reserved.

--- a/examples/basic.kts
+++ b/examples/basic.kts
@@ -1,5 +1,9 @@
 #!/usr/bin/env kotlinc -script --
 
+// A usage where the whole ArgsParser is copypasta'ed into the code. Suitable for situations
+// where you can't include/concatenate scripts to include the parser from a separate file (or
+// use maven-style deps)
+
 import java.lang.RuntimeException
 import kotlin.system.exitProcess
 

--- a/examples/kscript_deps_example.kts
+++ b/examples/kscript_deps_example.kts
@@ -1,13 +1,12 @@
 #!/usr/bin/env kscript
 
-@file:Import("../src/main/kotlin/ArgsParser.kt")
+@file:DependsOn("com.geekinasuit.micro:micro-kotlin-args:0.3")
 
 import java.lang.RuntimeException
 import kotlin.system.exitProcess
 
 class CLI(val args: ArgsParser) {
-  val foo by args.flag("--foo", help = "It's a foo, whaddya want?!") { toInt() }
-
+  val foo by args.flag("--foo", help = "It's a foo, whaddya want?!")
   val bar by args.opt("-b", help = "expecting lots of that B.")
 }
 
@@ -17,7 +16,7 @@ try {
     println(cli.args.help())
     exitProcess(0)
   }
-  println("FOO: ${cli.foo * 2}")
+  println("FOO: ${cli.foo}")
   println("BAR: ${cli.bar}")
 
 } catch (e: RuntimeException) {

--- a/examples/kscript_remote_example.kts
+++ b/examples/kscript_remote_example.kts
@@ -1,6 +1,6 @@
 #!/usr/bin/env kscript
 
-@file:Include("https://raw.githubusercontent.com/geekinasuit/micro-kotlin-args/v0.0.1/src/main/kotlin/ArgsParser.kt")
+@file:Import("https://raw.githubusercontent.com/geekinasuit/micro-kotlin-args/v0.0.1/src/main/kotlin/ArgsParser.kt")
 
 import java.lang.RuntimeException
 import kotlin.system.exitProcess
@@ -10,7 +10,7 @@ class CLI(val args: ArgsParser) {
   val bar by args.opt("-b", help = "expecting lots of that B.")
 }
 
-val cli = CLI(ArgsParser(*args, binaryName = "basic.kts"))
+val cli = CLI(ArgsParser(*args, name = "basic.kts"))
 try {
   if ("--help" in args) {
     println(cli.args.help())


### PR DESCRIPTION
Enumerated flags are specified such that the flag value itself determines the value given to the property, by way of a map. For instance, mapping an enum, like so:
```
  val environment by parser.enumerated(
    "--staging" to Environment.STAGING,
    "--production" to Environment.PRODUCTION,
    help = "The deployment environment"
  )
```
When the user puts one of `--staging` or `--production` the appropriate enum value will be set.

Also updates the README and the examples a bit, and fleshes out some tests. 